### PR TITLE
Glog is an autogen project, fix build script.

### DIFF
--- a/build/install-build-deps.py
+++ b/build/install-build-deps.py
@@ -106,7 +106,7 @@ _project_dep = (
      'checkout' : False,     
      'patch'    : os.path.abspath(os.path.join(ABC_PATH, 'external', 'glog', 'glog_abc_autotools.patch')),
      'path'     : os.path.abspath(os.path.join(TMP_PATH, 'glog')),
-     'autogen'  : False,
+     'autogen'  : True,
      'autotools': True,
      'install'  : True
  },


### PR DESCRIPTION
The install-build-deps.py script incorrectly thinks glog is not an autogen project, which breaks install because of the missing ./configure script.